### PR TITLE
Terraform 0.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,19 @@
 # Create VPC
 resource "huaweicloud_vpc_v1" "this" {
-  count = "${var.vpc_id=="" ? 1 : 0}"
-  name  = "${var.name}"
-  cidr  = "${var.cidr}"
+  count = var.vpc_id == "" ? 1 : 0
+  name  = var.name
+  cidr  = var.cidr
 }
 
 # Create Subnet
 resource "huaweicloud_vpc_subnet_v1" "this" {
-  count             = "${length(var.subnets)}"
-  name              = "${lookup(var.subnets[count.index], "name", null)}"
-  cidr              = "${lookup(var.subnets[count.index], "cidr", null)}"
-  gateway_ip        = "${lookup(var.subnets[count.index], "gateway_ip", null)}"
-  availability_zone = "${lookup(var.subnets[count.index], "availability_zone", null)}"
-  primary_dns       = "${lookup(var.subnets[count.index], "primary_dns", null)}"
-  secondary_dns     = "${lookup(var.subnets[count.index], "secondary_dns", null)}"
-  vpc_id            = "${var.vpc_id=="" ? join("",huaweicloud_vpc_v1.this.*.id) : var.vpc_id}"
+  count             = length(var.subnets)
+  name              = lookup(var.subnets[count.index], "name", null)
+  cidr              = lookup(var.subnets[count.index], "cidr", null)
+  gateway_ip        = lookup(var.subnets[count.index], "gateway_ip", null)
+  availability_zone = lookup(var.subnets[count.index], "availability_zone", null)
+  primary_dns       = lookup(var.subnets[count.index], "primary_dns", null)
+  secondary_dns     = lookup(var.subnets[count.index], "secondary_dns", null)
+  vpc_id            = var.vpc_id == "" ? join("", huaweicloud_vpc_v1.this.*.id) : var.vpc_id
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,15 @@
 output "this_vpc_id" {
   description = "The ID of the VPC"
-  value       = "${var.vpc_id=="" ? join("",huaweicloud_vpc_v1.this.*.id) : var.vpc_id}"
+  value       = var.vpc_id == "" ? join("", huaweicloud_vpc_v1.this.*.id) : var.vpc_id
 }
 
 output "this_subnet_ids" {
   description = "List of IDs of the Subnets"
-  value       = "${join(",",huaweicloud_vpc_subnet_v1.this.*.subnet_id)}"
+  value       = join(",", huaweicloud_vpc_subnet_v1.this.*.subnet_id)
 }
 
 output "this_network_ids" {
   description = "List of Network IDs of the Subnets"
-  value       = "${join(",",huaweicloud_vpc_subnet_v1.this.*.id)}"
+  value       = join(",", huaweicloud_vpc_subnet_v1.this.*.id)
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,13 @@ variable "cidr" {
 }
 
 variable "subnets" {
-  type = list(map(string))
   description = "List of subnets in the VPC"
-  default     = []
+  type = list(object({
+    name          = string
+    cidr          = string
+    gateway_ip    = string
+    primary_dns   = string
+    secondary_dns = string
+  }))
+  default = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
测试没有问题.

```terraform
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

module.vpc.huaweicloud_vpc_v1.this[0]: Refreshing state... [id=7e3654a5-7c34-4e8a-9318-1200cdec45da]
module.vpc.huaweicloud_vpc_subnet_v1.this[0]: Refreshing state... [id=eabe5df7-d71c-4cb4-9a06-33a71bebe7cb]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.vpc.huaweicloud_vpc_subnet_v1.this[0] will be created
  + resource "huaweicloud_vpc_subnet_v1" "this" {
      + availability_zone = (known after apply)
      + cidr              = "192.168.0.0/24"
      + dhcp_enable       = true
      + dns_list          = (known after apply)
      + gateway_ip        = "192.168.0.1"
      + id                = (known after apply)
      + name              = "default"
      + primary_dns       = "100.125.1.250"
      + region            = (known after apply)
      + secondary_dns     = "114.114.114.114"
      + subnet_id         = (known after apply)
      + vpc_id            = (known after apply)
    }

  # module.vpc.huaweicloud_vpc_v1.this[0] will be created
  + resource "huaweicloud_vpc_v1" "this" {
      + cidr   = "192.168.0.0/16"
      + id     = (known after apply)
      + name   = "vpc-infra-test"
      + region = (known after apply)
      + shared = (known after apply)
      + status = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```