### PR TITLE
chore(script): deprecate number definition and using integer

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -130,7 +130,7 @@
             "type": "string"
           },
           "priority": {
-            "type": "number"
+            "type": "integer"
           }
         }
       }


### PR DESCRIPTION
Replace the number's definition with the integer